### PR TITLE
Add python binding for `select_coupling_power_list`.

### DIFF
--- a/python/feyngraph/feyngraph.pyi
+++ b/python/feyngraph/feyngraph.pyi
@@ -365,6 +365,11 @@ class DiagramSelector:
         Add a constraint to only select diagrams for which the power of `coupling` sums to `power`.
         """
 
+    def select_coupling_power_list(self, coupling: str, powers: list[int]) -> None:
+        """
+        Add a constraint to only select diagrams for which the power of `coupling` sums to any of the values given in `powers`.
+        """
+
     def select_propagator_count(self, particle: str, count: int) -> None:
         """
         Add a constraint to only select diagrams which contain exactly `count` propagators of the field `particle`.

--- a/src/bindings/python/diagrams.rs
+++ b/src/bindings/python/diagrams.rs
@@ -893,6 +893,10 @@ impl PyDiagramSelector {
         self.0.select_coupling_power(&coupling, power);
     }
 
+    fn select_coupling_power_list(&mut self, coupling: String, powers: Vec<usize>) {
+        self.0.select_coupling_power_list(&coupling, powers);
+    }
+
     fn select_propagator_count(&mut self, particle: String, count: usize) {
         self.0.select_propagator_count(&particle, count);
     }


### PR DESCRIPTION
Extending the python bindings so that besides `select_coupling_power` also `select_coupling_power_list` is available.