### PR TITLE
Made model import methods generic over the path argument

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -525,10 +525,10 @@ impl Model {
     /// ```rust
     /// # use std::path::PathBuf;
     /// use feyngraph::Model;
-    /// let model = Model::from_ufo(&PathBuf::from("tests/resources/Standard_Model_UFO")).unwrap();
+    /// let model = Model::from_ufo("tests/resources/Standard_Model_UFO").unwrap();
     /// ```
-    pub fn from_ufo(path: &Path) -> Result<Self, ModelError> {
-        return ufo_parser::parse_ufo_model(path);
+    pub fn from_ufo(path: impl AsRef<Path>) -> Result<Self, ModelError> {
+        return ufo_parser::parse_ufo_model(path.as_ref());
     }
 
     /// Import a model in [QGRAF's](http://cefema-gt.tecnico.ulisboa.pt/~paulo/qgraf.html) model format. The parser is
@@ -539,10 +539,10 @@ impl Model {
     /// ```rust
     /// # use std::path::PathBuf;
     /// use feyngraph::Model;
-    /// let model = Model::from_qgraf(&PathBuf::from("tests/resources/sm.qgraf")).unwrap();
+    /// let model = Model::from_qgraf("tests/resources/sm.qgraf").unwrap();
     /// ```
-    pub fn from_qgraf(path: &Path) -> Result<Self, ModelError> {
-        return qgraf_parser::parse_qgraf_model(path);
+    pub fn from_qgraf(path: impl AsRef<Path>) -> Result<Self, ModelError> {
+        return qgraf_parser::parse_qgraf_model(path.as_ref());
     }
 
     /// Get the internal index of the anti-particle of the particle with the internal index `index`.


### PR DESCRIPTION
Change the `from_qgraf` and `from_ufo` model import methods to be generic over their argument. 

This makes them slightly more convenient to use and is in line with how path arguments are treated in the standard library, e.g. [File::open](https://doc.rust-lang.org/std/fs/struct.File.html#method.open). It also has the incidental benefit of enabling inlining across crate boundaries.