### PR TITLE
Expose LegView index and improve AssignWorkspace performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ default = []
 python-bindings = ["pyo3", "pyo3-log", "pyo3-ffi"]
 wolfram-bindings = ["python-bindings"]
 check_momenta = []
+qgraf-validation = []
 
 [[bench]]
 name = "topologies"

--- a/src/diagram/view.rs
+++ b/src/diagram/view.rs
@@ -467,6 +467,15 @@ impl LegView<'_> {
         }
         return result;
     }
+
+    /// Get the leg's ID.
+    ///
+    /// This is an index into [`DiagramView::legs`] and can be used to identify the leg.
+    /// For incoming legs, this is the index in `diagram.incoming_legs`, while
+    /// for outgoing legs, this is the index in `diagram.outgoing_legs` plus the number of incoming legs.
+    pub fn index(&self) -> usize {
+        return self.leg_index;
+    }
 }
 
 impl std::fmt::Display for LegView<'_> {

--- a/src/diagram/workspace.rs
+++ b/src/diagram/workspace.rs
@@ -116,14 +116,11 @@ impl<'a> AssignWorkspace<'a> {
                 })
                 .collect_vec();
             if !connected_particles.is_empty() {
+                let particle_counts = connected_particles.iter().counts();
                 candidates.retain(|candidate| {
-                    connected_particles
-                        .iter()
-                        .counts()
-                        .into_iter()
-                        .all(|(particle_index, count)| {
-                            count <= self.model.vertex(*candidate).particle_count(particle_index)
-                        })
+                    particle_counts.iter().all(|(&particle_index, &count)| {
+                        count <= self.model.vertex(*candidate).particle_count(particle_index)
+                    })
                 })
             }
             if candidates.is_empty() {

--- a/src/diagram/workspace.rs
+++ b/src/diagram/workspace.rs
@@ -102,27 +102,23 @@ impl<'a> AssignWorkspace<'a> {
             if self.vertex_candidates[index].degree == 1 {
                 continue;
             }
-            let connected_particles = self.get_connected_particles(index);
-            let mut candidates = self
+            let connected_particle_counts = self.get_connected_particles(index).into_iter().counts();
+            let candidates = self
                 .model
                 .vertices_iter()
                 .enumerate()
                 .filter_map(|(i, interaction)| {
-                    if interaction.degree() == self.vertex_candidates[index].degree {
+                    if interaction.degree() == self.vertex_candidates[index].degree
+                        && connected_particle_counts.iter().all(|(particle_index, &count)| {
+                            count <= self.model.vertex(i).particle_count(particle_index)
+                        })
+                    {
                         Some(i)
                     } else {
                         None
                     }
                 })
                 .collect_vec();
-            if !connected_particles.is_empty() {
-                let particle_counts = connected_particles.iter().counts();
-                candidates.retain(|candidate| {
-                    particle_counts.iter().all(|(&particle_index, &count)| {
-                        count <= self.model.vertex(*candidate).particle_count(particle_index)
-                    })
-                })
-            }
             if candidates.is_empty() {
                 return DiagramContainer::new(None, &self.topology.momentum_labels);
             }

--- a/tests/diagrams.rs
+++ b/tests/diagrams.rs
@@ -23,6 +23,7 @@ macro_rules! test_diagrams {
         $n_loops:literal
     ) => {
         paste!{
+            #[cfg(feature = "qgraf-validation")]
             #[test]
             fn [< test_diag _ $ufo _ $($particle_in)+ _ $($particle_out)+ _loops_ $n_loops >]() {
                 let model = Model::from_ufo(
@@ -76,6 +77,7 @@ macro_rules! test_diagrams {
         $n_loops:literal
     ) => {
         paste!{
+            #[cfg(feature = "qgraf-validation")]
             #[test]
             fn [< test_diag _ $ufo _ $name _loops_ $n_loops >]() {
                 let mut model = Model::from_ufo(


### PR DESCRIPTION
Let me know if you would rather I split this into a few PRs.

I found it hard to walk the graph without being able to inspect the leg index and it was private. So I added a pub method.

Once that was available, for the work I was doing, the `AssignWorkspace.assign` method became a large bottleneck:
<img width="866" height="605" alt="Screenshot 2026-06-12 at 12 25 13 AM" src="https://github.com/user-attachments/assets/80591189-a655-4293-a383-d9c23e4be1ae" />
Pre-computing the connected particle counts before looping over all vertex candidates significantly reduced the time spent in this function.